### PR TITLE
Fix broken setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='angrcli',
     version='0.1dev',
-    packages=['angrcli',],
+    packages=find_packages(),
     license='MIT',
     long_description='none',
 )


### PR DESCRIPTION
Without this fix only the first level package is installed, so only the angrcli/__init__.py file.