### PR TITLE
Fix regname in BVtoREG used before initialization

### DIFF
--- a/angrcli/plugins/context_view.py
+++ b/angrcli/plugins/context_view.py
@@ -103,12 +103,12 @@ class ContextView(SimStatePlugin):
         if type(bv) == str:
             return bv
         if "reg" in str(bv):
-            args = list()
+            replname = str(bv)
             for v in self.state.solver.describe_variables(bv):
                 if "reg" in v:
                     ridx = v[1]
                     regname = self.state.arch.register_names[ridx]
-            replname = str(bv).replace("reg_" + hex(ridx)[2:], regname)
+                    replname = replname.replace("reg_" + hex(ridx)[2:], regname)
             return replname
         return str(bv)
 


### PR DESCRIPTION
I triggered this bug while trying to adapt angr-cli to angrgdb. The code should be correct, test it.