### PR TITLE
Update to match release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='angrcli',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(exclude=['tests.*', 'tests', 'example.*', 'example']),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
If the installation is done with a Git checkout then there is a mismatch in the versioning.

That mismatch is present in the [current source tarball](https://github.com/fmagin/angr-cli/releases/tag/v1.1.1), too.